### PR TITLE
Moved hardcoded values to the config map

### DIFF
--- a/openshift/keycloak-configmap.app.yaml
+++ b/openshift/keycloak-configmap.app.yaml
@@ -24,3 +24,12 @@ objects:
     password: a2V5Y2xvYWs=
     database: a2V5Y2xvYWs=
     admin.password: cGFzc3dvcmQ=
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: keycloak-config
+  type: Opaque
+  data:
+    openshift.kube.ping.labels: "name=keycloak-server"
+    openshift.kube.ping.server.port: "47600"
+    operating.mode: "clustered"

--- a/openshift/keycloak.app.yaml
+++ b/openshift/keycloak.app.yaml
@@ -119,17 +119,17 @@ objects:
                 fieldPath: metadata.namespace
           - name: OPENSHIFT_KUBE_PING_LABELS
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: keycloak-config
                 key: openshift.kube.ping.labels
           - name: OPENSHIFT_KUBE_PING_SERVER_PORT
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: keycloak-config
                 key: openshift.kube.ping.server.port
           - name: OPERATING_MODE
             valueFrom:
-              secretKeyRef:
+              configMapKeyRef:
                 name: keycloak-config
                 key: operating.mode
           - name: JAVA_OPTS

--- a/openshift/keycloak.app.yaml
+++ b/openshift/keycloak.app.yaml
@@ -118,9 +118,20 @@ objects:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: OPENSHIFT_KUBE_PING_LABELS
-            value: 'name=keycloak-server'
+            valueFrom:
+              secretKeyRef:
+                name: keycloak-config
+                key: openshift.kube.ping.labels
           - name: OPENSHIFT_KUBE_PING_SERVER_PORT
-            value: '47600'
+            valueFrom:
+              secretKeyRef:
+                name: keycloak-config
+                key: openshift.kube.ping.server.port
+          - name: OPERATING_MODE
+            valueFrom:
+              secretKeyRef:
+                name: keycloak-config
+                key: operating.mode
           - name: JAVA_OPTS
             value: >-
               -server -Xms256m -Xmx1434m -XX:MetaspaceSize=96M
@@ -135,8 +146,6 @@ objects:
               -Djava.net.preferIPv4Stack=true
               -Djboss.modules.system.pkgs=org.jboss.byteman
               -Djava.awt.headless=true
-          - name: OPERATING_MODE
-            value: clustered
         restartPolicy: Always
         securityContext: {}
         terminationGracePeriodSeconds: 30


### PR DESCRIPTION
We have some hardcoded values in the template that should go to a config map kubernetes object