### PR TITLE
Change templates to deploy in standalone

### DIFF
--- a/openshift/keycloak-configmap.app.yaml
+++ b/openshift/keycloak-configmap.app.yaml
@@ -32,4 +32,4 @@ objects:
   data:
     openshift.kube.ping.labels: "name=keycloak-server"
     openshift.kube.ping.server.port: "47600"
-    operating.mode: "clustered"
+    operating.mode: "standalone"

--- a/openshift/keycloak.app.yaml
+++ b/openshift/keycloak.app.yaml
@@ -19,7 +19,7 @@ objects:
     triggers:
     - type: ConfigChange
     test: false
-    replicas: 2
+    replicas: 1
     selector:
       name: keycloak-server
     template:


### PR DESCRIPTION
We want to initially deploy keycloak in standalone mode in production then mode to cluster mode. That is why we apply this temporal changes here.

FYI @alexeykazakov 