### PR TITLE
Changed KC settings to use two owners and partition handling

### DIFF
--- a/docker/standalone-ha.xml
+++ b/docker/standalone-ha.xml
@@ -221,10 +221,10 @@
                 <local-cache name="users">
                     <eviction max-entries="10000" strategy="LIRS"/>
                 </local-cache>
-                <distributed-cache name="sessions" mode="SYNC" owners="1"/>
-                <distributed-cache name="authenticationSessions" mode="SYNC" owners="1"/>
-                <distributed-cache name="offlineSessions" mode="SYNC" owners="1"/>
-                <distributed-cache name="loginFailures" mode="SYNC" owners="1"/>
+                <distributed-cache name="sessions" mode="SYNC" owners="2"/>
+                <distributed-cache name="authenticationSessions" mode="SYNC" owners="2"/>
+                <distributed-cache name="offlineSessions" mode="SYNC" owners="2"/>
+                <distributed-cache name="loginFailures" mode="SYNC" owners="2"/>
                 <local-cache name="authorization">
                     <eviction max-entries="10000" strategy="LIRS"/>
                 </local-cache>

--- a/docker/standalone-ha.xml
+++ b/docker/standalone-ha.xml
@@ -221,10 +221,18 @@
                 <local-cache name="users">
                     <eviction max-entries="10000" strategy="LIRS"/>
                 </local-cache>
-                <distributed-cache name="sessions" mode="SYNC" owners="2"/>
-                <distributed-cache name="authenticationSessions" mode="SYNC" owners="2"/>
-                <distributed-cache name="offlineSessions" mode="SYNC" owners="2"/>
-                <distributed-cache name="loginFailures" mode="SYNC" owners="2"/>
+                <distributed-cache name="sessions" mode="SYNC" owners="2">
+                  <partition-handling enabled="true"/>
+                </distributed-cache>
+                <distributed-cache name="authenticationSessions" mode="SYNC" owners="2">
+                  <partition-handling enabled="true"/>
+                </distributed-cache>
+                <distributed-cache name="offlineSessions" mode="SYNC" owners="2">
+                  <partition-handling enabled="true"/>
+                </distributed-cache>
+                <distributed-cache name="loginFailures" mode="SYNC" owners="2">
+                  <partition-handling enabled="true"/>
+                </distributed-cache>
                 <local-cache name="authorization">
                     <eviction max-entries="10000" strategy="LIRS"/>
                 </local-cache>

--- a/openshift/keycloak.app.yaml
+++ b/openshift/keycloak.app.yaml
@@ -155,11 +155,8 @@ objects:
   apiVersion: v1
   metadata:
     name: keycloak-server
-    creationTimestamp: null
     labels:
       name: keycloak-server
-    annotations:
-      service.alpha.openshift.io/dependencies: '[{"name":"keycloak-postgresql","namespace":"","kind":"Service"}]'
   spec:
     ports:
     - port: 8080
@@ -174,7 +171,6 @@ objects:
 - kind: Route
   apiVersion: v1
   metadata:
-    creationTimestamp: null
     name: keycloak
   spec:
     host: ''


### PR DESCRIPTION
Infinispan developer suggested to increase the number of owners and add partition handling to improve the stability of the cluster.