### PR TITLE
Updated the Keycloak version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 @Library('github.com/fabric8io/fabric8-pipeline-library@master')
 def utils = new io.fabric8.Utils()
-def keycloakVersion = '3.2.0.CR1-SNAPSHOT'
+def keycloakVersion = '3.2.0.Final'
 
 node{
     properties([

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -11,7 +11,7 @@ PROJECT_NAME="keycloak"
 DOCKER_IMAGE_CORE=$PROJECT_NAME
 DOCKER_IMAGE_DEPLOY=$PROJECT_NAME-deploy
 
-KEYCLOAK_VERSION="3.2.0.CR1-SNAPSHOT"
+KEYCLOAK_VERSION="3.2.0.Final"
 
 # Source environment variables of the jenkins slave
 # that might interest this worker.
@@ -46,7 +46,7 @@ function install_deps() {
 
 function build() {
   echo 'CICO: Cloning keycloak source code repo'
-  git clone -b 3.2.0.Final  --depth 1 https://github.com/fabric8-services/keycloak.git
+  git clone -b $KEYCLOAK_VERSION  --depth 1 https://github.com/fabric8-services/keycloak.git
 
   cd keycloak
   # Set the version according to the ENV variable


### PR DESCRIPTION
we get problems when building the docker image:

```
archive-tmp	      keycloak-3.2.0.Final.tar.gz
keycloak-3.2.0.Final  keycloak-3.2.0.Final.zip
+ cd ..
+ echo 'CICO: keycloak-server build completed successfully!'
CICO: keycloak-server build completed successfully!
+ deploy
+ cp keycloak/distribution/server-dist/target/keycloak-3.2.0.CR1-SNAPSHOT.tar.gz docker
cp: cannot stat ‘keycloak/distribution/server-dist/target/keycloak-3.2.0.CR1-SNAPSHOT.tar.gz’: No such file or directory
Connection to 172.19.3.82 closed.
+ rtn_code=1
+ '[' 1 -eq 0 ']'
```