### PR TITLE
Use the right datasource version to match the xsl transformation

### DIFF
--- a/docker/changeDatabase.xsl
+++ b/docker/changeDatabase.xsl
@@ -2,7 +2,7 @@
 
 <xsl:stylesheet version="2.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:ds="urn:jboss:domain:datasources:5.0">
+    xmlns:ds="urn:jboss:domain:datasources:4.0">
 
   <xsl:output method="xml" indent="yes"/>
 


### PR DESCRIPTION
You downgraded the datasource version, then the transformation in the template was missing to add the postgresql datasource. That is why you're not getting the realm

here: https://github.com/fabric8-services/keycloak-deployment/commits/master/docker/standalone-ha.xml#diff-b286a87b24dcd76cbfbb21280bebb5c4L131