### PR TITLE
Set the replicas to one to avoid issues while running the script

### DIFF
--- a/openshift/keycloak.app.yaml
+++ b/openshift/keycloak.app.yaml
@@ -19,7 +19,7 @@ objects:
     triggers:
     - type: ConfigChange
     test: false
-    replicas: 3
+    replicas: 1
     selector:
       name: keycloak-server
     template:


### PR DESCRIPTION
I restore the amount of replicas to 1 to avoid issues when running the script of migration. Also, I changed in the config map in prod-preview, the value of operating mode from clustered to standalone