### PR TITLE
Set replicas to three for clustered mode

### DIFF
--- a/openshift/keycloak.app.yaml
+++ b/openshift/keycloak.app.yaml
@@ -19,7 +19,7 @@ objects:
     triggers:
     - type: ConfigChange
     test: false
-    replicas: 1
+    replicas: 3
     selector:
       name: keycloak-server
     template:


### PR DESCRIPTION
Once the deployment of v3.2.0.Final was successful in production, we can restore the clustered mode in prod-preview