### PR TITLE
Hardcode operating mode env variable

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ENV LAUNCH_JBOSS_IN_BACKGROUND 1
 ENV KEYCLOAK_VERSION 3.2.0.Final
 
 # This can be specified as build argument, e.g. docker build  --build-arg OPERATING_MODE=clustered --tag IMAGE_NAME .
-ARG OPERATING_MODE=standalone
+ARG OPERATING_MODE=clustered
 ENV OPERATING_MODE ${OPERATING_MODE}
 
 USER root

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -29,12 +29,11 @@ if [ $KEYCLOAK_USER ] && [ $KEYCLOAK_PASSWORD ]; then
 fi
 
 
-if [[ "${OPERATING_MODE}" == "clustered" ]]; then
-  echo "Starting keycloak-server on clustered mode..."
-  exec /opt/jboss/keycloak/bin/standalone.sh --server-config=standalone-ha.xml -bmanagement=$INTERNAL_POD_IP -bprivate=$INTERNAL_POD_IP $@
-else
+if [[ "${OPERATING_MODE}" != "clustered" ]]; then
   echo "Starting keycloak-server on standalone mode..."
   exec /opt/jboss/keycloak/bin/standalone.sh $@
-  #fi
+else
+  echo "Starting keycloak-server on clustered mode..."
+  exec /opt/jboss/keycloak/bin/standalone.sh --server-config=standalone-ha.xml -bmanagement=$INTERNAL_POD_IP -bprivate=$INTERNAL_POD_IP $@
 fi
 exit $?

--- a/openshift/keycloak-configmap.app.yaml
+++ b/openshift/keycloak-configmap.app.yaml
@@ -32,3 +32,4 @@ objects:
   data:
     openshift.kube.ping.labels: "name=keycloak-server"
     openshift.kube.ping.server.port: "47600"
+    operating.mode: "clustered"

--- a/openshift/keycloak-configmap.app.yaml
+++ b/openshift/keycloak-configmap.app.yaml
@@ -32,4 +32,3 @@ objects:
   data:
     openshift.kube.ping.labels: "name=keycloak-server"
     openshift.kube.ping.server.port: "47600"
-    operating.mode: "clustered"

--- a/openshift/keycloak.app.yaml
+++ b/openshift/keycloak.app.yaml
@@ -128,10 +128,7 @@ objects:
                 name: keycloak-config
                 key: openshift.kube.ping.server.port
           - name: OPERATING_MODE
-            valueFrom:
-              configMapKeyRef:
-                name: keycloak-config
-                key: operating.mode
+            value: "clustered"
           - name: JAVA_OPTS
             value: >-
               -server -Xms256m -Xmx1434m -XX:MetaspaceSize=96M


### PR DESCRIPTION
We had problems with the deployments due to a wrong value in the OPERATING_MODE en variable. So we decided to hardcode to avoid issues with out-of-date config maps. Moreover, we're not able to change the value of config maps in an automatized manner.