### PR TITLE
Fixing `Error from server: unrecognized type: int32`

### DIFF
--- a/openshift/keycloak.app.yaml
+++ b/openshift/keycloak.app.yaml
@@ -19,7 +19,7 @@ objects:
     triggers:
     - type: ConfigChange
     test: false
-    replicas: ${REPLICAS}
+    replicas: ${{REPLICAS}}
     selector:
       name: keycloak-server
     template:


### PR DESCRIPTION
Promotion to prod is failing https://ci.centos.org/view/Devtools/job/devtools-saas-openshiftio-promote-to-prod/436/