### PR TITLE
Remove keycloak route from OS template

### DIFF
--- a/openshift/keycloak.app.yaml
+++ b/openshift/keycloak.app.yaml
@@ -166,18 +166,6 @@ objects:
     sessionAffinity: None
   status:
     loadBalancer: {}
-- kind: Route
-  apiVersion: v1
-  metadata:
-    name: keycloak
-  spec:
-    host: ''
-    to:
-      kind: Service
-      name: keycloak-server
-      weight: 100
-      insecureEdgeTerminationPolicy: Allow
-    wildcardPolicy: None
 parameters:
 - name: IMAGE_TAG
   value: latest


### PR DESCRIPTION
We do not use "keycloak" route in Keycloak service. And it's not supposed to be used by other services. Keycloak is supposed to be accessed via the full public domain name like sso.openshift.io or sso.prod-preview.openshift.io only.
Hence we can remove it.

Everything should just work without this route but it's worth testing.

Fixes https://github.com/fabric8-services/fabric8-auth/issues/382