### PR TITLE
Set resource limits on Container level

### DIFF
--- a/openshift/keycloak.app.yaml
+++ b/openshift/keycloak.app.yaml
@@ -13,9 +13,6 @@ objects:
   spec:
     strategy:
       type: Rolling
-      resources:
-        limits:
-          memory: 2Gi
     triggers:
     - type: ConfigChange
     test: false
@@ -67,6 +64,9 @@ objects:
             timeoutSeconds: 5
             periodSeconds: 5
             initialDelaySeconds: 30
+          resources:
+            limits:
+              memory: 2Gi
           terminationMessagePath: /dev/termination-log
           env:
           - name: INTERNAL_POD_IP


### PR DESCRIPTION
Restrict how much memory the container can consume.

Limit to avoid it overtaking the cluster if the process were to go rogue.

Related to openshiftio/openshift.io#2685