### PR TITLE
Image as parameter for openshift template

### DIFF
--- a/openshift/keycloak.app.yaml
+++ b/openshift/keycloak.app.yaml
@@ -27,7 +27,7 @@ objects:
       spec:
         containers:
         - name: keycloak-server
-          image: registry.devshift.net/fabric8-services/keycloak-postgres:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}
           args:
             - '-b $(INTERNAL_POD_IP)'
             - '-Djgroups.bind_addr=global'
@@ -171,6 +171,8 @@ objects:
   status:
     loadBalancer: {}
 parameters:
+- name: IMAGE
+  value: registry.devshift.net/fabric8-services/keycloak-postgres
 - name: IMAGE_TAG
   value: latest
 - name: OPERATING_MODE


### PR DESCRIPTION
By enabling this commit we will be able to use different image urls for
staging and production:
https://github.com/openshiftio/saas-openshiftio/pull/790

We should merge first the above PR and then merge this one (so a new
build is triggered by jenkins)