### PR TITLE
Move to Quay.io

### DIFF
--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -17,13 +17,20 @@ BRANCH_NAME="3.2.0.Final-patch"
 # Source environment variables of the jenkins slave
 # that might interest this worker.
 function load_jenkins_vars() {
-  if [ -e "jenkins-env" ]; then
-    cat jenkins-env \
-      | grep -E "(DEVSHIFT_TAG_LEN|DEVSHIFT_USERNAME|DEVSHIFT_PASSWORD|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
-      | sed 's/^/export /g' \
-      > ~/.jenkins-env
-    source ~/.jenkins-env
-  fi
+    if [ -e "jenkins-env.json" ]; then
+        eval "$(./env-toolkit load -f jenkins-env.json \
+                  DEVSHIFT_TAG_LEN \
+                  QUAY_USERNAME \
+                  QUAY_PASSWORD \
+                  JENKINS_URL \
+                  GIT_BRANCH \
+                  GIT_COMMIT \
+                  BUILD_NUMBER \
+                  ghprbSourceBranch \
+                  ghprbActualCommit \
+                  BUILD_URL \
+                  ghprbPullId)"
+    fi
 }
 
 function install_deps() {
@@ -78,18 +85,20 @@ function deploy() {
   cp keycloak/distribution/server-dist/target/keycloak-$KEYCLOAK_VERSION.tar.gz docker
 
   TAG=$(echo $GIT_COMMIT | cut -c1-${DEVSHIFT_TAG_LEN})
-  REGISTRY="push.registry.devshift.net"
+  REGISTRY="quay.io"
 
-  if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-    docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${REGISTRY}
+  if [ -n "${QUAY_USERNAME}" -a -n "${QUAY_PASSWORD}" ]; then
+    docker login -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD} ${REGISTRY}
   else
     echo "Could not login, missing credentials for the registry"
   fi
 
   if [ "$TARGET" = "rhel" ]; then
     DOCKERFILE="Dockerfile.rhel"
+    IMAGE="${REGISTRY}/openshiftio/rhel-${REPO_NAME}-${PROJECT_NAME}-postgres"
   else
     DOCKERFILE="Dockerfile"
+    IMAGE="${REGISTRY}/openshiftio/${REPO_NAME}-${PROJECT_NAME}-postgres"
   fi
 
   # Let's deploy
@@ -97,13 +106,9 @@ function deploy() {
 
   rm docker/keycloak-$KEYCLOAK_VERSION.tar.gz
 
-  if [ "$TARGET" = "rhel" ]; then
-    tag_push ${REGISTRY}/osio-prod/${REPO_NAME}/${PROJECT_NAME}-postgres:$TAG
-    tag_push ${REGISTRY}/osio-prod/${REPO_NAME}/${PROJECT_NAME}-postgres:latest
-  else
-    tag_push ${REGISTRY}/${REPO_NAME}/${PROJECT_NAME}-postgres:$TAG
-    tag_push ${REGISTRY}/${REPO_NAME}/${PROJECT_NAME}-postgres:latest
-  fi
+  tag_push ${IMAGE}:${TAG}
+  tag_push ${IMAGE}:latest
+
   echo 'CICO: Image pushed, ready to update deployed app'
 }
 

--- a/docker/Dockerfile.rhel
+++ b/docker/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/jboss-jdk-8:latest
+FROM quay.io/openshiftio/rhel-base-jboss-jdk-8:latest
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"
 

--- a/openshift/keycloak.app.yaml
+++ b/openshift/keycloak.app.yaml
@@ -172,7 +172,7 @@ objects:
     loadBalancer: {}
 parameters:
 - name: IMAGE
-  value: registry.devshift.net/fabric8-services/keycloak-postgres
+  value: quay.io/openshiftio/rhel-fabric8-services-keycloak-postgres
 - name: IMAGE_TAG
   value: latest
 - name: OPERATING_MODE


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should
  not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo
to change the staging url from devshift to quay. The PR to the saas
repo should be merged before this one:
https://github.com/openshiftio/saas-openshiftio/pull/985